### PR TITLE
Fix/payment alert

### DIFF
--- a/src/views/booking/BoardBookings/BoardCard/BoardCard.js
+++ b/src/views/booking/BoardBookings/BoardCard/BoardCard.js
@@ -101,22 +101,14 @@ const BoardCard = ({
   useEffect(() => {
     const finalPayment = payments && payments.find((element) => element.paymentName === 'final' && element.status === 'succeeded');
     const previousEventDays = moment(date).diff(moment(), 'days');
-    const date1 = new Date();
-    date1.setHours(0, 0, 0, 0);
-    const date2 = new Date(date);
-
-    const diff = date2.getTime() - date1.getTime();
-    const diffDays = diff / (1000 * 3600 * 24);
-    console.log('date1', date1, 'date2', date2);
-    console.log('diffDays', diffDays);
 
     if (!finalPayment) {
-      if (diffDays < 0) {
-        setAlertMessage(`Booking has not been paid and event was ${diffDays * -1} days ago.`);
+      if (previousEventDays < 0) {
+        setAlertMessage(`Booking has not been paid and event was ${previousEventDays * -1} days ago.`);
         setShowAlertEventPayment('danger');
       }
-      if (diffDays < 7 && diffDays >= 0) {
-        setAlertMessage(`Booking has not been paid and event is in ${diffDays} days.`);
+      if (previousEventDays < 7 && previousEventDays >= 0) {
+        setAlertMessage(`Booking has not been paid and event is in ${previousEventDays === 0 ? 0 : previousEventDays + 1} days.`);
         setShowAlertEventPayment('warning');
       }
     }

--- a/src/views/booking/BoardBookings/BoardCard/BoardCard.js
+++ b/src/views/booking/BoardBookings/BoardCard/BoardCard.js
@@ -102,7 +102,7 @@ const BoardCard = ({
     const finalPayment = payments && payments.find((element) => element.paymentName === 'final' && element.status === 'succeeded');
     const previousEventDays = moment(date).diff(moment(), 'days');
 
-    if (!finalPayment) {
+    if (payments && payments.length > 0 && !finalPayment) {
       if (previousEventDays < 0) {
         setAlertMessage(`Booking has not been paid and event was ${previousEventDays * -1} days ago.`);
         setShowAlertEventPayment('danger');
@@ -293,10 +293,12 @@ const BoardCard = ({
             </small>
           </p>
         )}
-        {payments && payments.length > 0 && (
+        {alertMessage ? (
           <Alert color={showAlertEventPayment} className="m-0 p-0">
             <div className="alert-body small">{alertMessage}</div>
           </Alert>
+        ) : (
+          ''
         )}
       </div>
     );

--- a/src/views/booking/BoardBookings/BoardCard/BoardCard.js
+++ b/src/views/booking/BoardBookings/BoardCard/BoardCard.js
@@ -101,13 +101,22 @@ const BoardCard = ({
   useEffect(() => {
     const finalPayment = payments && payments.find((element) => element.paymentName === 'final' && element.status === 'succeeded');
     const previousEventDays = moment(date).diff(moment(), 'days');
+    const date1 = new Date();
+    date1.setHours(0, 0, 0, 0);
+    const date2 = new Date(date);
+
+    const diff = date2.getTime() - date1.getTime();
+    const diffDays = diff / (1000 * 3600 * 24);
+    console.log('date1', date1, 'date2', date2);
+    console.log('diffDays', diffDays);
+
     if (!finalPayment) {
-      if (previousEventDays < 0) {
-        setAlertMessage(`Booking has not been paid and event was ${previousEventDays * -1} days ago.`);
+      if (diffDays < 0) {
+        setAlertMessage(`Booking has not been paid and event was ${diffDays * -1} days ago.`);
         setShowAlertEventPayment('danger');
       }
-      if (previousEventDays < 7 && previousEventDays >= 0) {
-        setAlertMessage(`Booking has not been paid and event is in ${previousEventDays + 1} days.`);
+      if (diffDays < 7 && diffDays >= 0) {
+        setAlertMessage(`Booking has not been paid and event is in ${diffDays} days.`);
         setShowAlertEventPayment('warning');
       }
     }

--- a/src/views/booking/BoardBookings/BoardCard/BoardCard.js
+++ b/src/views/booking/BoardBookings/BoardCard/BoardCard.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import moment from 'moment';
 import { Calendar, Edit2, Repeat, User, Users, Check, DollarSign, Mail, Phone } from 'react-feather';
-import { Card, CardBody, CardHeader, CardFooter, Button, Media, CardLink, Badge } from 'reactstrap';
+import { Alert, Card, CardBody, CardHeader, CardFooter, Button, Media, CardLink, Badge } from 'reactstrap';
 import { useHistory } from 'react-router';
 
 // @scripts
@@ -58,6 +58,8 @@ const BoardCard = ({
   const [showFinalPaymentLabel, setShowFinalPaymentLabel] = useState(null);
   const [time, setTime] = useState(null);
   const [total, setTotal] = useState(0);
+  const [alertMessage, setAlertMessage] = useState(null);
+  const [showAlertEventPayment, setShowAlertEventPayment] = useState(null);
 
   const history = useHistory();
 
@@ -95,6 +97,21 @@ const BoardCard = ({
     setTime(dates && dates.time);
     setSignUpDeadlineToShow(dates && dates.signUpDeadline);
   }, [calendarEvent, signUpDeadline]);
+
+  useEffect(() => {
+    const finalPayment = payments && payments.find((element) => element.paymentName === 'final' && element.status === 'succeeded');
+    const previousEventDays = moment(date).diff(moment(), 'days');
+    if (!finalPayment) {
+      if (previousEventDays < 0) {
+        setAlertMessage(`Booking has not been paid and event was ${previousEventDays * -1} days ago.`);
+        setShowAlertEventPayment('danger');
+      }
+      if (previousEventDays < 7 && previousEventDays >= 0) {
+        setAlertMessage(`Booking has not been paid and event is in ${previousEventDays + 1} days.`);
+        setShowAlertEventPayment('warning');
+      }
+    }
+  }, [date, payments]);
 
   const cardBack = () => {
     return (
@@ -274,6 +291,11 @@ const BoardCard = ({
               {moment(updatedAt).fromNow()}
             </small>
           </p>
+        )}
+        {payments && payments.length > 0 && (
+          <Alert color={showAlertEventPayment} className="m-0 p-0">
+            <div className="alert-body small">{alertMessage}</div>
+          </Alert>
         )}
       </div>
     );


### PR DESCRIPTION
Adding payment alert:  when booking is near to its event date and there is no final payment, and when the event date alreay past and there is no final payment.